### PR TITLE
Add onboarding success redirect and guard

### DIFF
--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import { useAuth, UserProfile } from '@/hooks/use-auth';
 import { updateUserProfile } from '@/services/user-service';
+import { useRouter } from 'next/navigation';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -146,6 +147,7 @@ export default function OnboardingPage() {
   const [step, setStep] = useState(1);
   const { user, userProfile, updateUserProfileState } = useAuth();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
 
   const form = useForm<ProfileFormValues>({
     resolver: zodResolver(profileSchema),
@@ -166,8 +168,10 @@ export default function OnboardingPage() {
       };
       
       await updateUserProfile(user.uid, profileData);
-      
+
       updateUserProfileState(profileData);
+
+      router.push('/onboarding/success');
       
     } catch (error) {
       console.error("Failed to save profile", error);

--- a/src/app/onboarding/success/page.tsx
+++ b/src/app/onboarding/success/page.tsx
@@ -3,7 +3,7 @@
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { CheckCircle } from 'lucide-react'; // Importe o ícone CheckCircle
+import { CheckCircle, ArrowRight } from 'lucide-react';
 
 export default function OnboardingSuccessPage() {
   return (
@@ -12,22 +12,26 @@ export default function OnboardingSuccessPage() {
         <CardHeader className="flex flex-col items-center space-y-4">
           <CheckCircle className="h-16 w-16 text-green-500" />
           <CardTitle className="text-3xl font-bold text-green-600">
-            Seu ambiente de trabalho foi criado com sucesso!
+            Perfil concluído com sucesso!
           </CardTitle>
           <CardDescription className="text-lg text-muted-foreground">
-            Agora vamos criar seu primeiro agente inteligente. Ele será responsável por gerar documentos com IA, baseando-se em seus modelos.
+            Pronto! Agora você pode criar um workspace ou começar direto criando seu primeiro agente.
           </CardDescription>
         </CardHeader>
-        <CardContent>
-          {/* Conteúdo adicional opcional aqui */}
-        </CardContent>
-        <CardFooter className="flex justify-center">
-          <Button asChild className="bg-gradient-to-r from-indigo-500 to-purple-600 text-white hover:from-indigo-600 hover:to-purple-700">
-            <Link href="/agente/criar">
-              Criar meu primeiro agente
+        <CardContent className="flex justify-center gap-4">
+          <Button asChild variant="outline">
+            <Link href="/workspace">
+              Criar Workspace
+              <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
           </Button>
-        </CardFooter>
+          <Button asChild className="bg-gradient-to-r from-indigo-500 to-purple-600 text-white hover:from-indigo-600 hover:to-purple-700">
+            <Link href="/agente/criar">
+              Criar Agente
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          </Button>
+        </CardContent>
       </Card>
     </div>
   );

--- a/src/components/layout/onboarding-guard.tsx
+++ b/src/components/layout/onboarding-guard.tsx
@@ -53,6 +53,7 @@ export function OnboardingGuard({ children }: { children: React.ReactNode }) {
         '/workspace/success',
         '/agente/criar',
         '/settings',
+        '/onboarding/success',
       ];
       const isAllowed = allowedPaths.some(p => pathname.startsWith(p));
 


### PR DESCRIPTION
## Summary
- redirect to a success page after finishing the onboarding form
- allow `/onboarding/success` through `OnboardingGuard`
- tweak onboarding success page with guidance to create a workspace or agent

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: ESLint not configured)*

------
https://chatgpt.com/codex/tasks/task_e_685f707fdf88832b885ab11340e7991f